### PR TITLE
Feature/jibreen products endpoints

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter
 
-from app.api.routes import user, login, status, order
+from app.api.routes import product, user, login, status, order
 
 api_router = APIRouter()
 api_router.include_router(login.router, prefix="/login", tags=["login"])
 api_router.include_router(user.router, prefix="/users", tags=["users"])
 api_router.include_router(status.router, prefix="/statuses", tags=["statuses"])
 api_router.include_router(order.router, prefix="/orders", tags=["orders"])
+api_router.include_router(product.router, prefix="/products", tags=["products"])

--- a/app/api/routes/product.py
+++ b/app/api/routes/product.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+# make sure to remove this function
+@router.get("/example")
+def example():
+    return {"message": "this is an example"}

--- a/app/api/routes/product.py
+++ b/app/api/routes/product.py
@@ -1,8 +1,151 @@
-from fastapi import APIRouter
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+from fastapi import APIRouter, Depends, HTTPException,status
+from app.api.auth.oauth import get_current_admin_user
+from app.models import CreateProductRequestModel, CreateProductResponseModel, Product, ProductBaseModel, SearchRequest, SearchResult, UpdatedProductRequestModel, UpdatedProductResponseModel, User
+from app.database import products_db
 
 router = APIRouter()
 
-# make sure to remove this function
-@router.get("/example")
-def example():
-    return {"message": "this is an example"}
+@router.post("/", response_model=CreateProductResponseModel, status_code=status.HTTP_201_CREATED)
+async def create_product(product: CreateProductRequestModel, current_user: User = Depends(get_current_admin_user)): 
+    # Check for unique name
+    if any(p.name.lower() == product.name.lower() for p in products_db.values()):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, 
+                            detail=f"Product name '{product.name}' already exists. Please use a unique name.")
+
+    new_product = Product(
+        **product.dict()
+    )
+
+    products_db[str(new_product.id)] = new_product
+
+    return CreateProductResponseModel(
+        id = new_product.id,
+        name=new_product.name,
+        price= new_product.price,
+        description= new_product.description,
+        stock= new_product.stock,
+        isAvailable= new_product.isAvailable,
+        created_at= new_product.created_at
+        )
+
+
+   
+@router.put("/{product_id}",response_model=UpdatedProductResponseModel, status_code=status.HTTP_200_OK)
+async def update_product(product_id: UUID, product_update: UpdatedProductRequestModel, current_user: User = Depends(get_current_admin_user)):
+     
+    product_data = products_db.get(str(product_id))
+    
+    if not product_data:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    
+    # Convert product_data to a dictionary if it's a Product object
+    if isinstance(product_data, Product):
+        product_dict = product_data.dict()
+    else:
+        product_dict = product_data
+    
+    # Apply the updates (only update fields that were provided)
+    update_data = product_update.dict(exclude_unset=True)
+    
+    # Check for unique name if it's being updated
+    if 'name' in update_data and any(p.name.lower() == update_data['name'].lower() for p in products_db.values() if str(p.id) != str(product_id)):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, 
+            detail=f"Product name '{update_data['name']}' already exists. Please use a unique name."
+        )
+    
+    # Update product's attributes with new data
+    product_dict.update(update_data)
+    
+    # Update the 'updated_at' timestamp
+    product_dict["updated_at"] = datetime.now(timezone.utc)
+    
+    # Create a new Product object with updated data
+    updated_product = Product(**product_dict)
+    
+    # Update the product in the database
+    products_db[str(product_id)] = updated_product
+    
+    return UpdatedProductResponseModel(**updated_product.dict())
+
+
+
+@router.delete("/{product_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_product(product_id: UUID, current_user: User = Depends(get_current_admin_user)):
+    if str(product_id) in products_db:
+        del products_db[str(product_id)]
+    else:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail={"error":f"Product with ID {product_id} not found."})
+    
+
+
+@router.get("/", response_model=list[dict],status_code=status.HTTP_200_OK)
+def get_all_products():
+    
+    if not products_db:
+       return []
+    
+    return [
+            {
+                "id": product.id,
+                "name": product.name,
+                "price": product.price,
+                "stock": product.stock,
+                "isAvailable": product.isAvailable,
+                "created_at": product.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+            }
+            for product in products_db.values()
+        ]
+    
+    
+@router.get("/search", response_model=SearchResult , status_code=status.HTTP_200_OK)
+async def search_products(search_request: SearchRequest = Depends(SearchRequest)):
+    # Filter products based on search criteria
+    filtered_products = []
+    for product in products_db.values():
+        if (search_request.name is None or product.name.lower().find(search_request.name.lower()) != -1) and \
+           (search_request.min_price is None or product.price >= search_request.min_price) and \
+           (search_request.max_price is None or product.price <= search_request.max_price) and \
+           (search_request.isAvailable is None or product.isAvailable == search_request.isAvailable):
+            filtered_products.append(product)
+
+    # Sort products based on sort_by and sort_order
+    if search_request.sort_by == "price":
+        filtered_products.sort(key=lambda x: x.price, reverse=(search_request.sort_order == "desc"))
+    elif search_request.sort_by == "name":
+        filtered_products.sort(key=lambda x: x.name, reverse=(search_request.sort_order == "desc"))
+
+    # Paginate products
+    total_pages = -(-len(filtered_products) // search_request.page_size)  # Calculate total pages
+    products = filtered_products[(search_request.page-1)*search_request.page_size:search_request.page*search_request.page_size]
+
+    # Return search result
+    return SearchResult(
+        page=search_request.page,
+        total_pages=total_pages,
+        products_per_page=search_request.page_size,
+        total_products=len(filtered_products),
+        products=[{"id": p.id, "name": p.name, "price": p.price, "stock": p.stock, "isAvailable": p.isAvailable} for p in filtered_products]
+    )
+    
+@router.get("/{product_id}",response_model = dict, status_code=status.HTTP_200_OK)
+async def get_product(product_id: UUID):
+    try:
+        product = products_db.get(str(product_id))
+        return {
+            "id": product.id,
+            "name": product.name,
+            "price": product.price,
+            "description": product.description,
+            "stock": product.stock,
+            "isAvailable": product.isAvailable,
+            "created_at": product.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+        }
+        
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Product with ID {product_id} not found.".format(product_id))
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Product ID must be a valid UUID.")
+    

--- a/app/api/routes/product.py
+++ b/app/api/routes/product.py
@@ -142,8 +142,12 @@ async def search_products(search_request: SearchRequest = Depends(SearchRequest)
     
 @router.get("/{product_id}",response_model = GetProductResponseModel, status_code=status.HTTP_200_OK)
 async def get_product(product_id: UUID):
-    try:
+    
         product = products_db.get(str(product_id))
+        
+        if product is None:
+            raise HTTPException(status_code=404, detail=f"Product with ID {product_id} not found.".format(product_id))
+        
         return GetProductResponseModel(
             id=product.id,
             name=product.name,
@@ -154,8 +158,4 @@ async def get_product(product_id: UUID):
             updated_at=product.updated_at,
         )
         
-    except KeyError:
-        raise HTTPException(status_code=404, detail="Product with ID {product_id} not found.".format(product_id))
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Product ID must be a valid UUID.")
     

--- a/app/database.py
+++ b/app/database.py
@@ -32,3 +32,5 @@ users_db = {
 statusOrders_db = {}
 
 orders_db = {}
+
+products_db = {}

--- a/app/models.py
+++ b/app/models.py
@@ -215,9 +215,29 @@ class SearchRequest:
         self.sort_by = sort_by
         self.sort_order = sort_order
         
+class GetProductBySearchResponseModel(ProductBaseModel):
+    id: UUID
+    name: str
+    price: Decimal
+    stock: int
+    isAvailable: bool
+        
 class SearchResult(BaseModel):
     page: int
     total_pages: int
     products_per_page: int
     total_products: int
-    products: list[dict]
+    products: list[GetProductBySearchResponseModel]
+
+
+class GetProductResponseModel(ProductBaseModel):
+    id: UUID
+    name: str
+    price: Decimal
+    stock: int
+    isAvailable: bool
+    created_at: datetime
+    updated_at: Optional[datetime]
+
+    class Config:
+        json_encoders = {datetime: lambda v: v.strftime("%Y-%m-%d %H:%M:%S")}

--- a/app/models.py
+++ b/app/models.py
@@ -196,6 +196,7 @@ class UpdatedProductRequestModel(BaseModel):
     isAvailable: Optional[bool] = Field(default=None)
 
 class UpdatedProductResponseModel(ProductBaseModel):
+    id:UUID
     created_at: datetime
     updated_at: datetime
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from decimal import Decimal
 import re
 from typing import Optional
 from uuid import UUID, uuid4
@@ -157,3 +158,66 @@ class CreateStatusResponseModel(StatusModel):
 
     class Config:
         json_encoders = {datetime: lambda v: v.strftime("%Y-%m-%d %H:%M:%S")}
+        
+        
+        
+# ------------ Prodcut Model -----------------#
+class ProductBaseModel(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    price: Decimal = Field(...,description="Product price", ge=Decimal('0.01'), decimal_places=2)
+    description: Optional[str] = Field(None, max_length=1000)
+    stock: Optional[int] = Field(default=0, ge=0)
+    isAvailable: Optional[bool] = Field(default=True)
+
+
+class Product(ProductBaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: Optional[datetime] = Field(default=None)
+    
+
+class CreateProductRequestModel(ProductBaseModel):
+    pass  # All fields are inherited from ProductBaseModel
+
+class CreateProductResponseModel(ProductBaseModel):
+    id: UUID
+    created_at: datetime
+
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.strftime('%Y-%m-%d %H:%M:%S')
+        }
+
+class UpdatedProductRequestModel(BaseModel):
+    name: Optional[str] =  Field(None, min_length=1, max_length=100)
+    price: Optional[Decimal] = Field(None,description="Product price", ge=Decimal('0.01'), decimal_places=2)
+    description: Optional[str] = Field(None, max_length=1000)
+    stock: Optional[int] = Field(None, ge=0)
+    isAvailable: Optional[bool] = Field(default=None)
+
+class UpdatedProductResponseModel(ProductBaseModel):
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.strftime('%Y-%m-%d %H:%M:%S')
+        }
+        
+class SearchRequest:
+    def __init__(self, name: str = None, min_price: float = None, max_price: float = None, isAvailable: bool = None, page: int = 1, page_size: int = 20, sort_by: str = "name", sort_order: str = "asc"):
+        self.name = name
+        self.min_price = min_price
+        self.max_price = max_price
+        self.isAvailable = isAvailable
+        self.page = page
+        self.page_size = page_size
+        self.sort_by = sort_by
+        self.sort_order = sort_order
+        
+class SearchResult(BaseModel):
+    page: int
+    total_pages: int
+    products_per_page: int
+    total_products: int
+    products: list[dict]


### PR DESCRIPTION
### Product Management Endpoints

This module introduces CRUD (Create, Read, Update, Delete) endpoints for managing products in the e-commerce API. The implementation includes robust validation, error handling, and flexible search functionality.

#### Endpoints

#### 1. Create Product (`POST /`)
- Allows authorized admin users to create a new product.
- Ensures product names are unique.
- Returns product details, including `id`, `name`, `price`, `description`, `stock`, `isAvailable`, and `created_at`.

#### 2. Update Product (`PUT /{product_id}`)
- Allows authorized admin users to update a product by its UUID.
- Only updates the fields provided, leaving others unchanged.
- Ensures product name uniqueness during updates.
- Automatically updates the `updated_at` timestamp.

#### 3. Delete Product (`DELETE /{product_id}`)
- Allows authorized admin users to delete a product by its UUID.
- Returns `204 No Content` upon successful deletion.
- Raises an error if the product is not found.

#### 4. Get All Products (`GET /`)
- Retrieves a list of all available products, returning key information for each product.
- Returns an empty list if no products are available.

#### 5. Search Products (`GET /search`)
- Enables product search with flexible filters such as `name`, `min_price`, `max_price`, and `isAvailable` status.
- Supports sorting by `price` or `name`, with ascending or descending order.
- Includes pagination to manage large result sets.

#### 6. Get Product by ID (`GET /{product_id}`)
- Fetches detailed information about a specific product by its UUID.
- Provides product details such as `id`, `name`, `price`, `stock`, and timestamps.

### Validation and Error Handling
- Comprehensive validation for request inputs and proper error messages for various scenarios (e.g., duplicate product name, invalid UUID format).
- Uses appropriate HTTP status codes to signal success (`201 Created`, `200 OK`, `204 No Content`) and error conditions (`400 Bad Request`, `404 Not Found`).
